### PR TITLE
Update curl-invoke-docker.sh with healthcheck polling loop

### DIFF
--- a/dev/curl-invoke-docker.sh
+++ b/dev/curl-invoke-docker.sh
@@ -8,6 +8,21 @@ port=4000
 results_url=/workflow/results  # must be consistent with volume mount set in docker-run.sh
 params=$(yq -c '.test1.params' test-cases.yaml)
 
+max_attempts=10
+attempt=1
+wait_seconds=2
+while [ $attempt -le $max_attempts ]; do
+    echo "Health check; attempt $attempt of $max_attempts..."
+
+    curl -sf -o /dev/null -S http://localhost:${port}/docs && break
+
+    echo "Service not ready. Waiting $wait_seconds seconds before next attempt..."
+    sleep $wait_seconds
+
+    ((attempt++))
+done
+echo "Service ready!"
+
 curl --fail-with-body \
 -X POST "http://localhost:${port}/?execution_mode=${execution_mode}&mock_io=${mock_io}&results_url=${results_url}" \
 -H "Content-Type: application/json" \


### PR DESCRIPTION
Implements https://github.com/wildlife-dynamics/ecoscope-workflows/pull/528 here, to resolve ci failures seen on, e.g. #34 