### PR TITLE
pin ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
As a result of https://github.com/wildlife-dynamics/ecoscope-workflows/pull/631 we would need to pin ubuntu to the same version here to keep the snapshot tests from failing