### PR TITLE
Correct version tag

### DIFF
--- a/ecoscope-workflows-subject-tracking-workflow/VERSION.yaml
+++ b/ecoscope-workflows-subject-tracking-workflow/VERSION.yaml
@@ -1,1 +1,1 @@
-{MAJ: 0, MIN: 0, PATCH: 0}
+{MAJ: 18, MIN: 22, PATCH: 0}


### PR DESCRIPTION
I merged #206 with a bad version, evidently our tag check doesn't care about v0.0.0 :face_holding_back_tears: 